### PR TITLE
fix: allow any license

### DIFF
--- a/base.json
+++ b/base.json
@@ -61,12 +61,7 @@
 
     "valid-values-author": "off",
     "valid-values-engines": "off",
-    "valid-values-license": [ "error", [
-      "AGPL-3.0",
-      "AGPL-3.0-or-later",
-      "MIT",
-      "UNLICENSED"
-    ]],
+    "valid-values-license": "off",
     "valid-values-name-scope": "off",
     "valid-values-private": "off",
     "valid-values-publishConfig": "off",


### PR DESCRIPTION
As discussed, we can't really get the linter to usefully validate the license. Rather than linting the license using `npm-package-json-lint`, we will use SPDX directly, allowing for user overrides. Hence, this PR removes the license validation from our linter rules.